### PR TITLE
Update macro.py, fixed: could not load more than 32 macros

### DIFF
--- a/src/main/python/protocol/macro.py
+++ b/src/main/python/protocol/macro.py
@@ -186,7 +186,7 @@ class ProtocolMacro(BaseProtocol):
             full_macro.append(actions)
         if len(full_macro) < self.macro_count:
             full_macro += [[] for x in range(self.macro_count - len(full_macro))]
-        full_macro = full_macro[:self.macro_count]
+        # full_macro = full_macro[:self.macro_count]
         # TODO: log a warning if macro is cutoff
         data = self.macros_serialize(full_macro)[0:self.macro_memory]
         if data != self.macro:


### PR DESCRIPTION
fixed: could not load more than 32 macros

now it's possible to load all 109 macros.

![image](https://github.com/fxliang/vial-gui/assets/4023160/878be581-432b-4490-a0f7-fccb61301e14)
